### PR TITLE
RELEASE 2.0.0a0

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -82,7 +82,7 @@ m = setuptools.Extension(
 
 setuptools.setup(
     name="tinymetabobjloader",
-    version="2.0.0rc9.dev0",
+    version="2.0.0a0",
     description="Occasional fork of tinyobjloader",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Work around an issue in Poetry where dev releases like 2.0.0rc9.dev0 can't be installed.